### PR TITLE
Adds property model

### DIFF
--- a/examples/device_info.py
+++ b/examples/device_info.py
@@ -20,6 +20,7 @@ async def main():
     # check device name and s/n
     print(f"Device Name: {device.device_name}")
     print(f"Serial Number: {device.serial_number}")
+    print(f"Device Model: {device.model}")
     print(f"Outside air temp.: {device.outside_air_temperature} °C")
     print(f"Supply air temp.: {device.supply_air_temperature} °C")
     print(f"Extract air temp.: {device.extract_air_temperature} °C")

--- a/flexit_bacnet/device.py
+++ b/flexit_bacnet/device.py
@@ -49,8 +49,9 @@ class FlexitBACnet:
 
     @property
     def device_name(self) -> str:
-        """Return device name, e.g.: HvacFnct21y_A."""
-        device_name = self._get_value(self._device_property, bacnet.ReadValue.OBJECT_NAME)
+        """Return device name, e.g.: Flexit Nordic"""
+        device_name_from_device = self._get_value(self._device_property, bacnet.ReadValue.OBJECT_NAME)
+        device_name = DEVICE_NAMES.get(device_name_from_device)
 
         if not isinstance(device_name, str):
             return ''
@@ -69,7 +70,7 @@ class FlexitBACnet:
 
     @property
     def model(self) -> str:
-        """Return device's model, e.g.: Air handling unit Nordic S2 REL."""
+        """Return device's model, e.g.: S2 REL."""
         model = NORDIC_MODELS.get(int(self.serial_number[0:6]))
 
         if not isinstance(model, str):

--- a/flexit_bacnet/device.py
+++ b/flexit_bacnet/device.py
@@ -68,6 +68,16 @@ class FlexitBACnet:
         return serial_number
 
     @property
+    def model(self) -> str:
+        """Return device's model, e.g.: Air handling unit Nordic S2 REL."""
+        model = NORDIC_MODELS.get(int(self.serial_number[0:6]))
+
+        if not isinstance(model, str):
+            return ''
+
+        return model
+
+    @property
     def outside_air_temperature(self) -> float:
         """Outside air temperature in degrees Celsius, e.g. 14.3."""
         return float(round(self._get_value(OUTSIDE_AIR_TEMPERATURE), 1))

--- a/flexit_bacnet/nordic.py
+++ b/flexit_bacnet/nordic.py
@@ -166,19 +166,23 @@ DEVICE_PROPERTIES = [
 
 # The first six digits in the Nordic serial number corresponds to the Nordic model.
 NORDIC_MODELS = {
-    800111: "Nordic S2 REL",
-    800121: "Nordic S3 REL",
-    800110: "Nordic S2 RER",
-    800120: "Nordic S3 RER",
-    800221: "Nordic CL4 REL",
-    800220: "Nordic CL4 RER",
-    800130: "Nordic S4 RER",
-    800131: "Nordic S4 REL",
-    800210: "Nordic CL2 RER",
-    800211: "Nordic CL2 REL",
-    800200: "Nordic CL3 RER",
-    800201: "Nordic CL3 REL",
-    800300: "Nordic KS3 RER",
-    800301: "Nordic KS3 REL",
+    800111: "S2 REL",
+    800121: "S3 REL",
+    800110: "S2 RER",
+    800120: "S3 RER",
+    800221: "CL4 REL",
+    800220: "CL4 RER",
+    800130: "S4 RER",
+    800131: "S4 REL",
+    800210: "CL2 RER",
+    800211: "CL2 REL",
+    800200: "CL3 RER",
+    800201: "CL3 REL",
+    800300: "KS3 RER",
+    800301: "KS3 REL",
 }
 
+# The name of the device
+DEVICE_NAMES = {
+    "HvacFnct21y_A": "Flexit Nordic",
+}

--- a/flexit_bacnet/nordic.py
+++ b/flexit_bacnet/nordic.py
@@ -163,3 +163,22 @@ ROOM_3_HUMIDITY = DeviceProperty(ObjectType.ANALOG_VALUE, 2095)
 DEVICE_PROPERTIES = [
     item for _, item in globals().items() if isinstance(item, DeviceProperty)
 ]
+
+# The first six digits in the Nordic serial number corresponds to the Nordic model.
+NORDIC_MODELS = {
+    800111: "Nordic S2 REL",
+    800121: "Nordic S3 REL",
+    800110: "Nordic S2 RER",
+    800120: "Nordic S3 RER",
+    800221: "Nordic CL4 REL",
+    800220: "Nordic CL4 RER",
+    800130: "Nordic S4 RER",
+    800131: "Nordic S4 REL",
+    800210: "Nordic CL2 RER",
+    800211: "Nordic CL2 REL",
+    800200: "Nordic CL3 RER",
+    800201: "Nordic CL3 REL",
+    800300: "Nordic KS3 RER",
+    800301: "Nordic KS3 REL",
+}
+


### PR DESCRIPTION
I got a list of models from Flexit. It is really simple to extract the model from the serial number (the first six digits represents the model, the last six digits is just a consecutive number/serial number)

This is just a proposal.

The list with models are translated in Swedish, Norwegian, English and Finnish. If we want to translate the models that code should probably live in Home Assistant core.

Example output:
```
Device Name: HvacFnct21y_A
Serial Number: 800130-002967
Device Model: Air handling unit Nordic S4 RER
Outside air temp.: -1.4 °C
Supply air temp.: 17.9 °C
Extract air temp.: 20.0 °C
Exhaust air temp.: 2.9 °C
Room air temp.: 15.1 °C
Room 1 humidity: 0.0%
Room 2 humidity: 0.0%
Room 3 humidity: 0.0%
Comfort button state: True
Operation mode: 3
Ventilation mode: 3
Air temp. setpoint Away: 18.0 °C
Air temp. setpoint Home: 19.0 °C
Fireplace duration remaining: 10 minutes
Rapid ventilation duration remaining: 10 minutes
Supply air fan control signal: 74%
Supply air fan RPM: 2824
Exhaust air fan control signal: 70%
Exhaust air fan RPM: 2652
Electric heater enabled: True
Electric heater nominal power: 0.800000011920929 kW
Electric heater power consumption: 0.14538198709487915 kW
Fan setpoint - supply air Home: 74%
Fan setpoint - supply air Away: 42%
Fan setpoint - supply air High: 100%
Fan setpoint - supply air Cooker: 50%
Fan setpoint - supply air Fireplace: 90%
Fan setpoint - extract air Home: 70%
Fan setpoint - extract air Away: 40%
Fan setpoint - extract air High: 100%
Fan setpoint - extract air Cooker: 50%
Fan setpoint - extract air Fireplace: 50%
Air filter operating time: 8712.0 hours
Air filter exchange interval: 8784.0 days
Air filter polluted: False
Heat-exchanger efficiency: 80%
Heat-exchanger speed: 100%
```