### PR TITLE
Add support for EcoNordic BACnet objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,10 +50,7 @@ For example, changing ventilation mode can be done as follows:
 import asyncio
 
 # import FlexitBACnet
-from flexit_bacnet import (
-    FlexitBACnet,
-    VENTILATION_MODE_HIGH
-)
+from flexit_bacnet import FlexitBACnet
 
 
 async def main():
@@ -66,7 +63,7 @@ async def main():
     print('ventilation mode (before):', device.ventilation_mode)
 
     # set ventilation mode to High
-    await device.set_ventilation_mode(VENTILATION_MODE_HIGH)
+    await device.set_ventilation_mode(device.VENTILATION_MODE_HIGH)
 
     # check current ventilation mode again
     print('ventilation mode (after):', device.ventilation_mode)

--- a/examples/change_mode.py
+++ b/examples/change_mode.py
@@ -2,11 +2,7 @@ import asyncio
 import sys
 
 # import FlexitBACnet
-from flexit_bacnet import (
-    FlexitBACnet,
-    VENTILATION_MODE_AWAY,
-    VENTILATION_MODE_HOME,
-)
+from flexit_bacnet import FlexitBACnet
 
 
 async def main():
@@ -26,10 +22,10 @@ async def main():
     print(f"Ventilation mode (before): {device.ventilation_mode}")
 
     # check current ventilation mode and toggle it between HOME & AWAY
-    if device.ventilation_mode == VENTILATION_MODE_HOME:
-        await device.set_ventilation_mode(VENTILATION_MODE_AWAY)
-    elif device.ventilation_mode == VENTILATION_MODE_AWAY:
-        await device.set_ventilation_mode(VENTILATION_MODE_HOME)
+    if device.ventilation_mode == device.VENTILATION_MODE_HOME:
+        await device.set_ventilation_mode(device.VENTILATION_MODE_AWAY)
+    elif device.ventilation_mode == device.VENTILATION_MODE_AWAY:
+        await device.set_ventilation_mode(device.VENTILATION_MODE_HOME)
     else:
         print("This example toggles only between Home and Away modes.")
 

--- a/examples/device_info.py
+++ b/examples/device_info.py
@@ -21,6 +21,7 @@ async def main():
     print(f"Device Name: {device.device_name}")
     print(f"Serial Number: {device.serial_number}")
     print(f"Device Model: {device.model}")
+    print(f"Product Line: {device.product_line}")
     print(f"Outside air temp.: {device.outside_air_temperature} °C")
     print(f"Supply air temp.: {device.supply_air_temperature} °C")
     print(f"Extract air temp.: {device.extract_air_temperature} °C")
@@ -72,6 +73,17 @@ async def main():
     print(f"Air filter polluted: {device.air_filter_polluted}")
     print(f"Heat-exchanger efficiency: {device.heat_exchanger_efficiency}%")
     print(f"Heat-exchanger speed: {device.heat_exchanger_speed}%")
+
+    if device.product_line == "EcoNordic":
+        print(f"DHW operation mode: {device.dhw_operation_mode}")
+        print(f"DHW temperature setpoint (comfort): {device.dhw_temperature_setpoint_comfort} °C")
+        print(f"DHW temperature setpoint (economy): {device.dhw_temperature_setpoint_economy} °C")
+        print(f"DHW tank temperature (top): {device.dhw_tank_temperature_top} °C")
+        print(f"DHW tank temperature (middle): {device.dhw_tank_temperature_middle} °C")
+        print(f"DHW tank temperature (bottom): {device.dhw_tank_temperature_bottom} °C")
+        print(f"DHW electric heater status: {device.dhw_electric_heater_status}%")
+        print(f"Space heating setpoint: {device.space_heating_setpoint} °C")
+        print(f"Heat pump state: {device.heat_pump_state}")
 
 
 if __name__ == "__main__":

--- a/flexit_bacnet/__init__.py
+++ b/flexit_bacnet/__init__.py
@@ -1,4 +1,3 @@
 from flexit_bacnet.bacnet import DecodingError
 from flexit_bacnet.bacnet import discover
 from flexit_bacnet.device import FlexitBACnet
-from flexit_bacnet.nordic import *

--- a/flexit_bacnet/bacnet.py
+++ b/flexit_bacnet/bacnet.py
@@ -74,6 +74,7 @@ class ObjectType(IntEnum):
     ANALOG_VALUE = 2
     BINARY_VALUE = 5
     DEVICE = 8
+    MULTI_STATE_INPUT = 13
     MULTI_STATE_VALUE = 19
     POSITIVE_INTEGER_VALUE = 48
 

--- a/flexit_bacnet/device.py
+++ b/flexit_bacnet/device.py
@@ -1,7 +1,7 @@
 from typing import Any, Optional
 
 from flexit_bacnet import bacnet
-from flexit_bacnet.nordic import *
+from flexit_bacnet import econordic, nordic
 
 
 class FlexitBACnet:
@@ -15,23 +15,55 @@ class FlexitBACnet:
         self.device_id = device_id
         self._state: Optional[bacnet.DeviceState] = None
 
+        # property mapping for the specific product line (nordic/econordic)
+        self._prop_map: Optional[Any] = None
+
     @property
-    def _device_property(self) -> DeviceProperty:
-        return DeviceProperty(
-            ObjectType.DEVICE,
+    def _device_property(self) -> bacnet.DeviceProperty:
+        return bacnet.DeviceProperty(
+            bacnet.ObjectType.DEVICE,
             self.device_id,
             read_values=[bacnet.ReadValue.OBJECT_NAME, bacnet.ReadValue.DESCRIPTION],
         )
 
+    async def _get_property_mapping(self) -> Any:
+        """
+        Return the property mapping module based on the device model ID.
+
+        The model ID is derived from the serial number:
+        - If the model exists in econordic.MODELS, the econordic module is returned.
+        - If the model exists in nordic.MODELS, the nordic module is returned.
+        - Otherwise a ValueError is raised.
+        """
+        self._state = await self.bacnet.read_multiple([self._device_property])
+
+        model_id = int(self.serial_number[0:6])
+
+        if model_id in econordic.MODELS:
+            return econordic
+
+        if model_id in nordic.MODELS:
+            return nordic
+
+        raise ValueError(f"Unsupported model id: {model_id}")
+
     async def update(self) -> None:
         """Refresh local device state."""
-        device_properties = DEVICE_PROPERTIES + [self._device_property]
+        if self._prop_map is None:
+            self._prop_map = await self._get_property_mapping()
+
+            # Dynamically add constants from the property map to the device object
+            for name in dir(self._prop_map):
+                if name.isupper():  # only consider constants (uppercase names)
+                    setattr(self, name, getattr(self._prop_map, name))
+
+        device_properties = self._prop_map.DEVICE_PROPERTIES + [self._device_property]
 
         self._state = await self.bacnet.read_multiple(device_properties)
 
     def _get_value(
         self,
-        device_property: DeviceProperty,
+        device_property: bacnet.DeviceProperty,
         value_name: Optional[bacnet.ReadValue] = None,
     ) -> Any:
 
@@ -43,15 +75,20 @@ class FlexitBACnet:
 
         return dict(self._state[device_property.object_identifier])[value_name]
 
-    async def _set_value(self, device_property: DeviceProperty, value: Any) -> None:
+    async def _set_value(self, device_property: bacnet.DeviceProperty, value: Any) -> None:
         await self.bacnet.write(device_property, value)
         await self.update()
+
+    @property
+    def product_line(self) -> str:
+        """Return product line, e.g.: Nordic or EcoNordic."""
+        return self._prop_map.PRODUCT_LINE
 
     @property
     def device_name(self) -> str:
         """Return device name, e.g.: Flexit Nordic"""
         device_name_from_device = self._get_value(self._device_property, bacnet.ReadValue.OBJECT_NAME)
-        device_name = DEVICE_NAMES.get(device_name_from_device)
+        device_name = self._prop_map.DEVICE_NAMES.get(device_name_from_device)
 
         if not isinstance(device_name, str):
             return ''
@@ -76,39 +113,39 @@ class FlexitBACnet:
         except ValueError:
             return ''
 
-        return NORDIC_MODELS.get(model_id, '')
+        return self._prop_map.MODELS.get(model_id, '')
 
     @property
     def outside_air_temperature(self) -> float:
         """Outside air temperature in degrees Celsius, e.g. 14.3."""
-        return float(round(self._get_value(OUTSIDE_AIR_TEMPERATURE), 1))
+        return float(round(self._get_value(self._prop_map.OUTSIDE_AIR_TEMPERATURE), 1))
 
     @property
     def supply_air_temperature(self) -> float:
         """Supply air temperature in degrees Celsius, e.g. 18.9."""
-        return float(round(self._get_value(SUPPLY_AIR_TEMPERATURE), 1))
+        return float(round(self._get_value(self._prop_map.SUPPLY_AIR_TEMPERATURE), 1))
 
     @property
     def exhaust_air_temperature(self) -> float:
         """Exhaust air temperature in degrees Celsius, e.g. 14.5."""
-        return float(round(self._get_value(EXHAUST_AIR_TEMPERATURE), 1))
+        return float(round(self._get_value(self._prop_map.EXHAUST_AIR_TEMPERATURE), 1))
 
     @property
     def extract_air_temperature(self) -> float:
         """Extract air temperature in degrees Celsius, e.g. 14.3."""
-        value = float(round(self._get_value(EXTRACT_AIR_TEMPERATURE), 1))
+        value = float(round(self._get_value(self._prop_map.EXTRACT_AIR_TEMPERATURE), 1))
 
         # as some models use different object identifier for extract air temperature
         # we need to check if the value is 0.0 and try to read the alternative value
         if value == 0.0:
-            value = float(round(self._get_value(EXTRACT_AIR_TEMPERATURE_ALT), 1))
+            value = float(round(self._get_value(self._prop_map.EXTRACT_AIR_TEMPERATURE_ALT), 1))
 
         return value
 
     @property
     def extract_air_humidity(self) -> float:
         """Extract air relative humidity in %, e.g. 40.3."""
-        return float(round(self._get_value(EXTRACT_AIR_HUMIDITY), 1))
+        return float(round(self._get_value(self._prop_map.EXTRACT_AIR_HUMIDITY), 1))
 
     @property
     def room_temperature(self) -> float:
@@ -116,7 +153,7 @@ class FlexitBACnet:
 
         Temperature is read from the temperature sensor on a CI70 panel.
         """
-        return float(round(self._get_value(ROOM_TEMPERATURE), 1))
+        return float(round(self._get_value(self._prop_map.ROOM_TEMPERATURE), 1))
 
     @property
     def room_1_humidity(self) -> float:
@@ -124,7 +161,7 @@ class FlexitBACnet:
 
         RH value from CI77 - RH sensor 1.
         """
-        return float(round(self._get_value(ROOM_1_HUMIDITY), 1))
+        return float(round(self._get_value(self._prop_map.ROOM_1_HUMIDITY), 1))
 
     @property
     def room_2_humidity(self) -> float:
@@ -132,7 +169,7 @@ class FlexitBACnet:
 
         RH value from CI77 - RH sensor 2.
         """
-        return float(round(self._get_value(ROOM_2_HUMIDITY), 1))
+        return float(round(self._get_value(self._prop_map.ROOM_2_HUMIDITY), 1))
 
     @property
     def room_3_humidity(self) -> float:
@@ -140,29 +177,29 @@ class FlexitBACnet:
 
         RH value from CI77 - RH sensor 3.
         """
-        return float(round(self._get_value(ROOM_3_HUMIDITY), 1))
+        return float(round(self._get_value(self._prop_map.ROOM_3_HUMIDITY), 1))
 
     @property
     def comfort_button(self) -> bool:
         """Comfort button state, True if active."""
-        return self._get_value(COMFORT_BUTTON) == COMFORT_BUTTON_ACTIVE
+        return self._get_value(self._prop_map.COMFORT_BUTTON) == self._prop_map.COMFORT_BUTTON_ACTIVE
 
     async def activate_comfort_button(self) -> None:
         """Activate comfort button."""
-        await self._set_value(COMFORT_BUTTON, COMFORT_BUTTON_ACTIVE)
+        await self._set_value(self._prop_map.COMFORT_BUTTON, self._prop_map.COMFORT_BUTTON_ACTIVE)
 
     async def deactivate_comfort_button(self, delay: int = 0) -> None:
         """Deactivate comfort button with optional delay (in minutes)."""
         if delay < 0 or delay > 600:
             raise ValueError("delay must be between 0 and 600 minutes")
 
-        await self._set_value(COMFORT_BUTTON_DELAY, delay)
-        await self._set_value(COMFORT_BUTTON, COMFORT_BUTTON_INACTIVE)
+        await self._set_value(self._prop_map.COMFORT_BUTTON_DELAY, delay)
+        await self._set_value(self._prop_map.COMFORT_BUTTON, self._prop_map.COMFORT_BUTTON_INACTIVE)
 
     @property
     def operation_mode(self) -> int:
         """Returns current heat exchanger operation mode, e.g. Home."""
-        return self._get_value(OPERATION_MODE)
+        return self._get_value(self._prop_map.OPERATION_MODE)
 
     @property
     def ventilation_mode(self) -> int:
@@ -171,7 +208,7 @@ class FlexitBACnet:
         This setting only works when comfort_button is active.
         When inactive, this will always return VENTILATION_MODE_AWAY.
         """
-        return self._get_value(VENTILATION_MODE)
+        return self._get_value(self._prop_map.VENTILATION_MODE)
 
     async def set_ventilation_mode(self, mode: int) -> None:
         """Set ventilation mode to one of the supported values:
@@ -180,31 +217,31 @@ class FlexitBACnet:
         3 - Home (VENTILATION_MODE_HOME)
         4 - High (VENTILATION_MODE_HIGH)
         """
-        await self._set_value(VENTILATION_MODE, mode)
+        await self._set_value(self._prop_map.VENTILATION_MODE, mode)
 
     @property
     def air_temp_setpoint_away(self) -> float:
         """Return temperature setpoint for Away mode."""
-        return float(self._get_value(AIR_TEMP_SETPOINT_AWAY))
+        return float(self._get_value(self._prop_map.AIR_TEMP_SETPOINT_AWAY))
 
     async def set_air_temp_setpoint_away(self, temperature: float):
         """Set temperature setpoint for Away mode.
 
         temperature -- temperature in degrees Celsius
         """
-        await self._set_value(AIR_TEMP_SETPOINT_AWAY, temperature)
+        await self._set_value(self._prop_map.AIR_TEMP_SETPOINT_AWAY, temperature)
 
     @property
     def air_temp_setpoint_home(self) -> float:
         """Return temperature setpoint for Home mode."""
-        return float(self._get_value(AIR_TEMP_SETPOINT_HOME))
+        return float(self._get_value(self._prop_map.AIR_TEMP_SETPOINT_HOME))
 
     async def set_air_temp_setpoint_home(self, temperature: float) -> None:
         """Set temperature setpoint for Home mode.
 
         temperature -- temperature in degrees Celsius
         """
-        await self._set_value(AIR_TEMP_SETPOINT_HOME, temperature)
+        await self._set_value(self._prop_map.AIR_TEMP_SETPOINT_HOME, temperature)
 
     async def start_fireplace_ventilation(self, minutes: int) -> None:
         """Set duration and trigger fireplace ventilation mode.
@@ -219,212 +256,356 @@ class FlexitBACnet:
 
         minutes -- duration of fireplace ventilation in minutes (1 - 360)
         """
-        await self._set_value(FIREPLACE_VENTILATION_RUNTIME, minutes)
+        await self._set_value(self._prop_map.FIREPLACE_VENTILATION_RUNTIME, minutes)
 
     @property
     def fireplace_mode_runtime(self) -> int:
         """Returns currently set runtime for the fireplace mode (in minutes)."""
-        return self._get_value(FIREPLACE_VENTILATION_RUNTIME)
+        return self._get_value(self._prop_map.FIREPLACE_VENTILATION_RUNTIME)
 
     async def trigger_fireplace_mode(self) -> None:
         """Trigger temporary fireplace ventilation mode."""
-        await self._set_value(FIREPLACE_VENTILATION, FIREPLACE_VENTILATION_TRIGGER)
+        await self._set_value(self._prop_map.FIREPLACE_VENTILATION, self._prop_map.FIREPLACE_VENTILATION_TRIGGER)
 
     @property
     def fireplace_ventilation_status(self) -> bool:
         """Return true if fireplace mode is active."""
-        return self._get_value(FIREPLACE_STATE) == FIREPLACE_STATE_ACTIVE
+        return self._get_value(self._prop_map.FIREPLACE_STATE) == self._prop_map.FIREPLACE_STATE_ACTIVE
 
     @property
     def fireplace_ventilation_remaining_duration(self) -> int:
         """Return remaining duration (in minutes) of fireplace ventilation mode."""
-        return int(self._get_value(FIREPLACE_VENTILATION_REMAINING_DURATION))
+        return int(self._get_value(self._prop_map.FIREPLACE_VENTILATION_REMAINING_DURATION))
 
     async def start_rapid_ventilation(self, minutes: int) -> None:
         """Trigger temporary rapid ventilation mode.
 
         minutes -- duration of rapid ventilation in minutes (1 - 360)
         """
-        await self._set_value(RAPID_VENTILATION_RUNTIME, minutes)
-        await self._set_value(RAPID_VENTILATION, RAPID_VENTILATION_TRIGGER)
+        await self._set_value(self._prop_map.RAPID_VENTILATION_RUNTIME, minutes)
+        await self._set_value(self._prop_map.RAPID_VENTILATION, self._prop_map.RAPID_VENTILATION_TRIGGER)
 
     @property
     def rapid_ventilation_remaining_duration(self) -> int:
         """Return remaining duration (in minutes) of fireplace ventilation mode."""
-        return int(self._get_value(RAPID_VENTILATION_REMAINING_DURATION))
+        return int(self._get_value(self._prop_map.RAPID_VENTILATION_REMAINING_DURATION))
 
     @property
     def supply_air_fan_control_signal(self) -> int:
         """Return current supply air fan control signal (in %)."""
-        return int(self._get_value(FAN_SPEED_SUPPLY_AIR))
+        return int(self._get_value(self._prop_map.FAN_SPEED_SUPPLY_AIR))
 
     @property
     def supply_air_fan_rpm(self) -> int:
         """Return current supply air fan RPM."""
-        return int(self._get_value(TACHO_SUPPLY_FAN))
+        return int(self._get_value(self._prop_map.TACHO_SUPPLY_FAN))
 
     @property
     def exhaust_air_fan_control_signal(self) -> int:
         """Return current exhaust air fan control signal (in %)."""
-        return int(self._get_value(FAN_SPEED_EXHAUST_AIR))
+        return int(self._get_value(self._prop_map.FAN_SPEED_EXHAUST_AIR))
 
     @property
     def exhaust_air_fan_rpm(self) -> int:
         """Return current exhaust air fan RPM."""
-        return int(self._get_value(TACHO_EXHAUST_FAN))
+        return int(self._get_value(self._prop_map.TACHO_EXHAUST_FAN))
 
     @property
     def electric_heater(self) -> bool:
         """Return True if electric heater is enabled."""
-        return bool(self._get_value(ELECTRICAL_HEATER) == ELECTRICAL_HEATER_ACTIVE)
+        return bool(self._get_value(self._prop_map.ELECTRICAL_HEATER) == self._prop_map.ELECTRICAL_HEATER_ACTIVE)
 
     async def enable_electric_heater(self) -> None:
         """Enables electric air heater."""
-        await self._set_value(ELECTRICAL_HEATER, ELECTRICAL_HEATER_ACTIVE)
+        await self._set_value(self._prop_map.ELECTRICAL_HEATER, self._prop_map.ELECTRICAL_HEATER_ACTIVE)
 
     async def disable_electric_heater(self) -> None:
         """Disables electric air heater."""
-        await self._set_value(ELECTRICAL_HEATER, ELECTRICAL_HEATER_INACTIVE)
+        await self._set_value(self._prop_map.ELECTRICAL_HEATER, self._prop_map.ELECTRICAL_HEATER_INACTIVE)
 
     @property
     def electric_heater_nominal_power(self) -> float:
         """Return nominal heater power in kilowatts."""
-        return float(self._get_value(ELECTRIC_HEATER_NOM_POWER))
+        return float(self._get_value(self._prop_map.ELECTRIC_HEATER_NOM_POWER))
 
     @property
     def electric_heater_power(self) -> float:
         """Return heater power consumption in kilowatts."""
-        return float(self._get_value(HEATING_COIL_ELECTRIC_POWER))
+        return float(self._get_value(self._prop_map.HEATING_COIL_ELECTRIC_POWER))
 
     @property
     def cooker_hood_status(self) -> bool:
         """Cooker hood ventilation state, True if active."""
-        return self._get_value(COOKER_HOOD) == COOKER_HOOD_ACTIVE
+        return self._get_value(self._prop_map.COOKER_HOOD) == self._prop_map.COOKER_HOOD_ACTIVE
 
     async def activate_cooker_hood(self) -> None:
         """Activates cooker hood mode."""
-        await self._set_value(COOKER_HOOD, COOKER_HOOD_ACTIVE)
+        await self._set_value(self._prop_map.COOKER_HOOD, self._prop_map.COOKER_HOOD_ACTIVE)
 
     async def deactivate_cooker_hood(self) -> None:
         """Deactivates cooker hood mode."""
-        await self._set_value(COOKER_HOOD, COOKER_HOOD_INACTIVE)
+        await self._set_value(self._prop_map.COOKER_HOOD, self._prop_map.COOKER_HOOD_INACTIVE)
 
     @property
     def fan_setpoint_supply_air_home(self) -> int:
         """Return fan setpoint for supply air HOME in percent."""
-        return int(self._get_value(LINEAR_SETPOINT_SUPPLY_AIR_HOME))
+        return int(self._get_value(self._prop_map.LINEAR_SETPOINT_SUPPLY_AIR_HOME))
 
     async def set_fan_setpoint_supply_air_home(self, percent: int) -> None:
         """Set fan setpoint for supply air HOME in percent."""
-        await self._set_value(LINEAR_SETPOINT_SUPPLY_AIR_HOME, percent)
+        await self._set_value(self._prop_map.LINEAR_SETPOINT_SUPPLY_AIR_HOME, percent)
 
     @property
     def fan_setpoint_extract_air_home(self) -> int:
         """Return fan setpoint for extract air HOME in percent."""
-        return int(self._get_value(LINEAR_SETPOINT_EXHAUST_AIR_HOME))
+        return int(self._get_value(self._prop_map.LINEAR_SETPOINT_EXHAUST_AIR_HOME))
 
     async def set_fan_setpoint_extract_air_home(self, percent: int) -> None:
         """Set fan setpoint for extract air HOME in percent."""
-        await self._set_value(LINEAR_SETPOINT_EXHAUST_AIR_HOME, percent)
+        await self._set_value(self._prop_map.LINEAR_SETPOINT_EXHAUST_AIR_HOME, percent)
 
     @property
     def fan_setpoint_supply_air_high(self) -> int:
         """Return fan setpoint for supply air HIGH in percent."""
-        return int(self._get_value(LINEAR_SETPOINT_SUPPLY_AIR_HIGH))
+        return int(self._get_value(self._prop_map.LINEAR_SETPOINT_SUPPLY_AIR_HIGH))
 
     async def set_fan_setpoint_supply_air_high(self, percent: int) -> None:
         """Set fan setpoint for supply air HIGH in percent."""
-        await self._set_value(LINEAR_SETPOINT_SUPPLY_AIR_HIGH, percent)
+        await self._set_value(self._prop_map.LINEAR_SETPOINT_SUPPLY_AIR_HIGH, percent)
 
     @property
     def fan_setpoint_extract_air_high(self) -> int:
         """Return fan setpoint for extract air HIGH in percent."""
-        return int(self._get_value(LINEAR_SETPOINT_EXHAUST_AIR_HIGH))
+        return int(self._get_value(self._prop_map.LINEAR_SETPOINT_EXHAUST_AIR_HIGH))
 
     async def set_fan_setpoint_extract_air_high(self, percent: int) -> None:
         """Set fan setpoint for extract air HIGH in percent."""
-        await self._set_value(LINEAR_SETPOINT_EXHAUST_AIR_HIGH, percent)
+        await self._set_value(self._prop_map.LINEAR_SETPOINT_EXHAUST_AIR_HIGH, percent)
 
     @property
     def fan_setpoint_supply_air_away(self) -> int:
         """Return fan setpoint for supply air AWAY in percent."""
-        return int(self._get_value(LINEAR_SETPOINT_SUPPLY_AIR_AWAY))
+        return int(self._get_value(self._prop_map.LINEAR_SETPOINT_SUPPLY_AIR_AWAY))
 
     async def set_fan_setpoint_supply_air_away(self, percent: int) -> None:
         """Set fan setpoint for supply air AWAY in percent."""
-        await self._set_value(LINEAR_SETPOINT_SUPPLY_AIR_AWAY, percent)
+        await self._set_value(self._prop_map.LINEAR_SETPOINT_SUPPLY_AIR_AWAY, percent)
 
     @property
     def fan_setpoint_extract_air_away(self) -> int:
         """Return fan setpoint for extract air AWAY in percent."""
-        return int(self._get_value(LINEAR_SETPOINT_EXHAUST_AIR_AWAY))
+        return int(self._get_value(self._prop_map.LINEAR_SETPOINT_EXHAUST_AIR_AWAY))
 
     async def set_fan_setpoint_extract_air_away(self, percent: int) -> None:
         """Set fan setpoint for extract air AWAY in percent."""
-        await self._set_value(LINEAR_SETPOINT_EXHAUST_AIR_AWAY, percent)
+        await self._set_value(self._prop_map.LINEAR_SETPOINT_EXHAUST_AIR_AWAY, percent)
 
     @property
     def fan_setpoint_supply_air_cooker(self) -> int:
         """Return fan setpoint for supply air COOKER in percent."""
-        return int(self._get_value(LINEAR_SETPOINT_SUPPLY_AIR_COOKER))
+        return int(self._get_value(self._prop_map.LINEAR_SETPOINT_SUPPLY_AIR_COOKER))
 
     async def set_fan_setpoint_supply_air_cooker(self, percent: int) -> None:
         """Set fan setpoint for supply air COOKER in percent."""
-        await self._set_value(LINEAR_SETPOINT_SUPPLY_AIR_COOKER, percent)
+        await self._set_value(self._prop_map.LINEAR_SETPOINT_SUPPLY_AIR_COOKER, percent)
 
     @property
     def fan_setpoint_extract_air_cooker(self) -> int:
         """Return fan setpoint for extract air COOKER in percent."""
-        return int(self._get_value(LINEAR_SETPOINT_EXHAUST_AIR_COOKER))
+        return int(self._get_value(self._prop_map.LINEAR_SETPOINT_EXHAUST_AIR_COOKER))
 
     async def set_fan_setpoint_extract_air_cooker(self, percent: int) -> None:
         """Set fan setpoint for extract air COOKER in percent."""
-        await self._set_value(LINEAR_SETPOINT_EXHAUST_AIR_COOKER, percent)
+        await self._set_value(self._prop_map.LINEAR_SETPOINT_EXHAUST_AIR_COOKER, percent)
 
     @property
     def fan_setpoint_supply_air_fire(self) -> int:
         """Return fan setpoint for supply air FIRE in percent."""
-        return int(self._get_value(LINEAR_SETPOINT_SUPPLY_AIR_FIRE))
+        return int(self._get_value(self._prop_map.LINEAR_SETPOINT_SUPPLY_AIR_FIRE))
 
     async def set_fan_setpoint_supply_air_fire(self, percent: int):
         """Set fan setpoint for supply air FIRE in percent."""
-        await self._set_value(LINEAR_SETPOINT_SUPPLY_AIR_FIRE, percent)
+        await self._set_value(self._prop_map.LINEAR_SETPOINT_SUPPLY_AIR_FIRE, percent)
 
     @property
     def fan_setpoint_extract_air_fire(self) -> int:
         """Return fan setpoint for extract air FIRE in percent."""
-        return int(self._get_value(LINEAR_SETPOINT_EXHAUST_AIR_FIRE))
+        return int(self._get_value(self._prop_map.LINEAR_SETPOINT_EXHAUST_AIR_FIRE))
 
     async def set_fan_setpoint_extract_air_fire(self, percent: int) -> None:
         """Set fan setpoint for extract air FIRE in percent."""
-        await self._set_value(LINEAR_SETPOINT_EXHAUST_AIR_FIRE, percent)
+        await self._set_value(self._prop_map.LINEAR_SETPOINT_EXHAUST_AIR_FIRE, percent)
 
     @property
     def air_filter_operating_time(self) -> float:
         """Return air filter operating time in hours."""
-        return float(self._get_value(AIR_FILTER_OPERATING_TIME))
+        return float(self._get_value(self._prop_map.AIR_FILTER_OPERATING_TIME))
 
     @property
     def air_filter_exchange_interval(self) -> float:
-        return float(self._get_value(AIR_FILTER_TIME_PERIOD_FOR_EXCHANGE))
+        """Return air filter exchange interval in hours."""
+        return float(self._get_value(self._prop_map.AIR_FILTER_TIME_PERIOD_FOR_EXCHANGE))
 
     @property
     def heat_exchanger_efficiency(self) -> int:
         """Returns heat exchanger efficiency in percent."""
-        return int(round(self._get_value(ROTATING_HEAT_EXCHANGER_EFFICIENCY)))
+        return int(round(self._get_value(self._prop_map.ROTATING_HEAT_EXCHANGER_EFFICIENCY)))
 
     @property
     def heat_exchanger_speed(self) -> int:
         """Returns heat exchanger speed in percent."""
-        return int(round(self._get_value(ROTATING_HEAT_EXCHANGER_SPEED)))
+        return int(round(self._get_value(self._prop_map.ROTATING_HEAT_EXCHANGER_SPEED)))
 
     @property
     def air_filter_polluted(self) -> bool:
         """Returns True if filter is polluted."""
-        return bool(self._get_value(AIR_FILTER_POLLUTED) == AIR_FILTER_POLLUTED_ACTIVE)
+        return bool(self._get_value(self._prop_map.AIR_FILTER_POLLUTED) == self._prop_map.AIR_FILTER_POLLUTED_ACTIVE)
 
     async def reset_air_filter_timer(self) -> None:
         """Resets air filter replace timer."""
         await self._set_value(
-            AIR_FILTER_REPLACE_TIMER_RESET, AIR_FILTER_REPLACE_TIMER_RESET_TRIGGER
+            self._prop_map.AIR_FILTER_REPLACE_TIMER_RESET, self._prop_map.AIR_FILTER_REPLACE_TIMER_RESET_TRIGGER
         )
+
+    @property
+    def dhw_operation_mode(self) -> int:
+        """Returns current Domestic Hot Water (DHW) operation mode."""
+
+        if self.product_line != econordic.PRODUCT_LINE:
+            raise Exception("DHW operation mode is only available on EcoNordic models") 
+
+        return self._get_value(econordic.DHW_OPERATION_MODE)
+    
+    async def set_dhw_operation_mode(self, mode: int) -> None:
+        """Set Domestic Hot Water (DHW) operation mode.
+
+        mode -- one of the supported values:
+        1 - Comfort (DHW_OPERATION_MODE_COMFORT)
+        2 - Economy (DHW_OPERATION_MODE_ECONOMY)
+        """
+
+        if self.product_line != econordic.PRODUCT_LINE:
+            raise Exception("DHW operation mode is only available on EcoNordic models")
+
+        await self._set_value(econordic.DHW_OPERATION_MODE, mode)
+
+    async def dhw_temporary_boost_start(self) -> None:
+        """Activate Domestic Hot Water (DHW) temporary boost mode."""
+
+        if self.product_line != econordic.PRODUCT_LINE:
+            raise Exception("DHW temporary boost is only available on EcoNordic models")
+
+        await self._set_value(econordic.DHW_TEMPORARY_BOOST, econordic.DHW_TEMPORARY_BOOST_START)
+
+    async def dhw_temporary_boost_stop(self) -> None:
+        """Deactivate Domestic Hot Water (DHW) temporary boost mode."""
+
+        if self.product_line != econordic.PRODUCT_LINE:
+            raise Exception("DHW temporary boost is only available on EcoNordic models")
+
+        await self._set_value(econordic.DHW_TEMPORARY_BOOST, econordic.DHW_TEMPORARY_BOOST_STOP)
+
+    @property
+    def dhw_temperature_setpoint_comfort(self) -> float:
+        """Return Domestic Hot Water (DHW) temperature setpoint for Comfort mode."""
+
+        if self.product_line != econordic.PRODUCT_LINE:
+            raise Exception("DHW temperature setpoint is only available on EcoNordic models")
+
+        return float(self._get_value(econordic.DHW_TEMPERATURE_SETPOINT_COMFORT))
+
+    async def set_dhw_temperature_setpoint_comfort(self, temperature: float) -> None:
+        """Set Domestic Hot Water (DHW) temperature setpoint for Comfort mode.
+
+        temperature -- temperature in degrees Celsius
+        """
+
+        if self.product_line != econordic.PRODUCT_LINE:
+            raise Exception("DHW temperature setpoint is only available on EcoNordic models")
+
+        await self._set_value(econordic.DHW_TEMPERATURE_SETPOINT_COMFORT, temperature)
+
+    @property
+    def dhw_temperature_setpoint_economy(self) -> float:
+        """Return Domestic Hot Water (DHW) temperature setpoint for Economy mode."""
+
+        if self.product_line != econordic.PRODUCT_LINE:
+            raise Exception("DHW temperature setpoint is only available on EcoNordic models")
+
+        return float(self._get_value(econordic.DHW_TEMPERATURE_SETPOINT_ECONOMY))
+
+    async def set_dhw_temperature_setpoint_economy(self, temperature: float) -> None:
+        """Set Domestic Hot Water (DHW) temperature setpoint for Economy mode.
+
+        temperature -- temperature in degrees Celsius
+        """
+
+        if self.product_line != econordic.PRODUCT_LINE:
+            raise Exception("DHW temperature setpoint is only available on EcoNordic models")
+
+        await self._set_value(econordic.DHW_TEMPERATURE_SETPOINT_ECONOMY, temperature)
+
+    @property
+    def dhw_tank_temperature_top(self) -> float:
+        """Return Domestic Hot Water (DHW) tank top temperature."""
+
+        if self.product_line != econordic.PRODUCT_LINE:
+            raise Exception("DHW tank temperature is only available on EcoNordic models")
+
+        return float(self._get_value(econordic.DHW_TANK_TEMPERATURE_TOP))
+
+    @property
+    def dhw_tank_temperature_middle(self) -> float:
+        """Return Domestic Hot Water (DHW) tank middle temperature."""
+
+        if self.product_line != econordic.PRODUCT_LINE:
+            raise Exception("DHW tank temperature is only available on EcoNordic models")
+
+        return float(self._get_value(econordic.DHW_TANK_TEMPERATURE_MIDDLE))
+
+    @property
+    def dhw_tank_temperature_bottom(self) -> float:
+        """Return Domestic Hot Water (DHW) tank bottom temperature."""
+
+        if self.product_line != econordic.PRODUCT_LINE:
+            raise Exception("DHW tank temperature is only available on EcoNordic models")
+
+        return float(self._get_value(econordic.DHW_TANK_TEMPERATURE_BOTTOM))
+
+    @property
+    def dhw_electric_heater_status(self) -> int:
+        """Return Domestic Hot Water (DHW) electric heater status (0 - 100%)."""
+
+        if self.product_line != econordic.PRODUCT_LINE:
+            raise Exception("DHW electric heater status is only available on EcoNordic models")
+
+        return int(self._get_value(econordic.DHW_ELECTRIC_HEATER_STATUS))
+
+    @property
+    def space_heating_setpoint(self) -> float:
+        """Return room temperature setpoint for heating circuit 1."""
+
+        if self.product_line != econordic.PRODUCT_LINE:
+            raise Exception("Space heating setpoint is only available on EcoNordic models")
+
+        return float(self._get_value(econordic.HEATING_CIRCUIT_1_ROOM_TEMPERATURE_SETPOINT))
+
+    async def set_space_heating_setpoint(self, temperature: float) -> None:
+        """Set room temperature setpoint for heating circuit 1.
+
+        temperature -- temperature in degrees Celsius
+        """
+
+        if self.product_line != econordic.PRODUCT_LINE:
+            raise Exception("Space heating setpoint is only available on EcoNordic models")
+
+        await self._set_value(econordic.HEATING_CIRCUIT_1_ROOM_TEMPERATURE_SETPOINT, temperature)
+
+    @property
+    def heat_pump_state(self) -> int:
+        """Return heat pump state."""
+
+        if self.product_line != econordic.PRODUCT_LINE:
+            raise Exception("Heat pump state is only available on EcoNordic models")
+
+        return int(self._get_value(econordic.HEAT_PUMP_STATE))

--- a/flexit_bacnet/econordic.py
+++ b/flexit_bacnet/econordic.py
@@ -1,10 +1,11 @@
-"""Flexit Nordic series config.
+"""Flexit EcoNordic series config.
 
-Based on https://www.flexit.no/globalassets/catalog/documents/bacnet-nordic-basic_2963.xlsx
+Based on information from mwahss on Home Assistant Community Forum:
+https://community.home-assistant.io/t/flexit-nordic-bacnet-roadmap-ideas/675223/60
 """
 from .bacnet import DeviceProperty, ObjectType
 
-PRODUCT_LINE = "Nordic"
+PRODUCT_LINE = "EcoNordic"
 
 # Comfort button [RW]
 # 0 = Ventilation mode Away after Away delay timer duration [Pintval,318].
@@ -44,29 +45,29 @@ AIR_TEMP_SETPOINT_AWAY = DeviceProperty(ObjectType.ANALOG_VALUE, 1985)
 AIR_TEMP_SETPOINT_HOME = DeviceProperty(ObjectType.ANALOG_VALUE, 1994)
 
 # Trigger temporary fireplace ventilation
-FIREPLACE_VENTILATION = DeviceProperty(ObjectType.MULTI_STATE_VALUE, 360)
+FIREPLACE_VENTILATION = DeviceProperty(ObjectType.MULTI_STATE_VALUE, 358)
 FIREPLACE_VENTILATION_TRIGGER = 2
 
 # Fireplace ventilation runtime (e.g. 10 minutes)
 FIREPLACE_VENTILATION_RUNTIME = DeviceProperty(ObjectType.POSITIVE_INTEGER_VALUE, 270)
 
 # Fireplace ventilation remaining time in minutes
-FIREPLACE_VENTILATION_REMAINING_DURATION = DeviceProperty(ObjectType.ANALOG_VALUE, 2038)
+FIREPLACE_VENTILATION_REMAINING_DURATION = DeviceProperty(ObjectType.ANALOG_VALUE, 2036)
 
 # Fireplace status
-FIREPLACE_STATE = DeviceProperty(ObjectType.BINARY_VALUE, 400)
+FIREPLACE_STATE = DeviceProperty(ObjectType.BINARY_VALUE, 421)
 FIREPLACE_STATE_ACTIVE = 1
 FIREPLACE_STATE_INACTIVE = 0
 
 # Trigger temporary rapid ventilation
-RAPID_VENTILATION = DeviceProperty(ObjectType.MULTI_STATE_VALUE, 357)
+RAPID_VENTILATION = DeviceProperty(ObjectType.MULTI_STATE_VALUE, 355)
 RAPID_VENTILATION_TRIGGER = 2
 
 # Rapid ventilation runtime (e.g. 10 minutes)
 RAPID_VENTILATION_RUNTIME = DeviceProperty(ObjectType.POSITIVE_INTEGER_VALUE, 293)
 
 # Rapid ventilation remaining time in minutes
-RAPID_VENTILATION_REMAINING_DURATION = DeviceProperty(ObjectType.ANALOG_VALUE, 2031)
+RAPID_VENTILATION_REMAINING_DURATION = DeviceProperty(ObjectType.ANALOG_VALUE, 2029)
 
 # Outside air temperature (e.g. 10.680000305175781 degreesCelsius)
 OUTSIDE_AIR_TEMPERATURE = DeviceProperty(ObjectType.ANALOG_INPUT, 1)
@@ -114,39 +115,39 @@ ELECTRIC_HEATER_NOM_POWER = DeviceProperty(ObjectType.ANALOG_VALUE, 190)
 HEATING_COIL_ELECTRIC_POWER = DeviceProperty(ObjectType.ANALOG_VALUE, 194)
 
 # Cooker hood, activate (e.g. inactive)
-COOKER_HOOD = DeviceProperty(ObjectType.BINARY_VALUE, 402, priority=13)
+COOKER_HOOD = DeviceProperty(ObjectType.BINARY_VALUE, 2, priority=13)
 COOKER_HOOD_ACTIVE = 1
 COOKER_HOOD_INACTIVE = 0
 
 # Linear, setpoint supply air HIGH (e.g. 100.0 percent)
-LINEAR_SETPOINT_SUPPLY_AIR_HIGH = DeviceProperty(ObjectType.ANALOG_VALUE, 1835)
+LINEAR_SETPOINT_SUPPLY_AIR_HIGH = DeviceProperty(ObjectType.ANALOG_VALUE, 20)
 
 # Linear, setpoint supply air HOME (e.g. 70.0 percent)
-LINEAR_SETPOINT_SUPPLY_AIR_HOME = DeviceProperty(ObjectType.ANALOG_VALUE, 1836)
+LINEAR_SETPOINT_SUPPLY_AIR_HOME = DeviceProperty(ObjectType.ANALOG_VALUE, 19)
 
 # Linear, setpoint supply air AWAY (e.g. 50.0 percent)
-LINEAR_SETPOINT_SUPPLY_AIR_AWAY = DeviceProperty(ObjectType.ANALOG_VALUE, 1837)
+LINEAR_SETPOINT_SUPPLY_AIR_AWAY = DeviceProperty(ObjectType.ANALOG_VALUE, 18)
 
 # Linear, setpoint supply air FIRE (e.g. 90.0 percent)
-LINEAR_SETPOINT_SUPPLY_AIR_FIRE = DeviceProperty(ObjectType.ANALOG_VALUE, 1838)
+LINEAR_SETPOINT_SUPPLY_AIR_FIRE = DeviceProperty(ObjectType.ANALOG_VALUE, 16)
 
 # Linear, setpoint supply air COOKER (e.g. 90.0 percent)
-LINEAR_SETPOINT_SUPPLY_AIR_COOKER = DeviceProperty(ObjectType.ANALOG_VALUE, 1839)
+LINEAR_SETPOINT_SUPPLY_AIR_COOKER = DeviceProperty(ObjectType.ANALOG_VALUE, 15)
 
 # Linear, setpoint exhaust air HIGH (e.g. 100.0 percent)
-LINEAR_SETPOINT_EXHAUST_AIR_HIGH = DeviceProperty(ObjectType.ANALOG_VALUE, 1840)
+LINEAR_SETPOINT_EXHAUST_AIR_HIGH = DeviceProperty(ObjectType.ANALOG_VALUE, 14)
 
 # Linear, setpoint exhaust air HOME (e.g. 70.0 percent)
-LINEAR_SETPOINT_EXHAUST_AIR_HOME = DeviceProperty(ObjectType.ANALOG_VALUE, 1841)
+LINEAR_SETPOINT_EXHAUST_AIR_HOME = DeviceProperty(ObjectType.ANALOG_VALUE, 13)
 
 # Linear, setpoint exhaust air AWAY (e.g. 50.0 percent)
-LINEAR_SETPOINT_EXHAUST_AIR_AWAY = DeviceProperty(ObjectType.ANALOG_VALUE, 1842)
+LINEAR_SETPOINT_EXHAUST_AIR_AWAY = DeviceProperty(ObjectType.ANALOG_VALUE, 12)
 
 # Linear, setpoint exhaust air FIRE (e.g. 50.0 percent)
-LINEAR_SETPOINT_EXHAUST_AIR_FIRE = DeviceProperty(ObjectType.ANALOG_VALUE, 1843)
+LINEAR_SETPOINT_EXHAUST_AIR_FIRE = DeviceProperty(ObjectType.ANALOG_VALUE, 11)
 
 # Linear, setpoint exhaust air COOKER (e.g. 50.0 percent)
-LINEAR_SETPOINT_EXHAUST_AIR_COOKER = DeviceProperty(ObjectType.ANALOG_VALUE, 1844)
+LINEAR_SETPOINT_EXHAUST_AIR_COOKER = DeviceProperty(ObjectType.ANALOG_VALUE, 10)
 
 # Air filter, operating time (e.g. 0.0 hours)
 AIR_FILTER_OPERATING_TIME = DeviceProperty(ObjectType.ANALOG_VALUE, 285)
@@ -159,7 +160,7 @@ AIR_FILTER_POLLUTED = DeviceProperty(ObjectType.BINARY_VALUE, 522)
 AIR_FILTER_POLLUTED_ACTIVE = 1
 
 # Air filter replace timer reset (e.g. 1 None)
-AIR_FILTER_REPLACE_TIMER_RESET = DeviceProperty(ObjectType.MULTI_STATE_VALUE, 613)
+AIR_FILTER_REPLACE_TIMER_RESET = DeviceProperty(ObjectType.MULTI_STATE_VALUE, 609)
 AIR_FILTER_REPLACE_TIMER_RESET_TRIGGER = 2
 
 # Humidity sensors
@@ -168,6 +169,47 @@ ROOM_1_HUMIDITY = DeviceProperty(ObjectType.ANALOG_VALUE, 2093)
 ROOM_2_HUMIDITY = DeviceProperty(ObjectType.ANALOG_VALUE, 2094)
 ROOM_3_HUMIDITY = DeviceProperty(ObjectType.ANALOG_VALUE, 2095)
 
+# DHW - Domestic Hot Water
+
+# DHW operating mode
+DHW_OPERATION_MODE = DeviceProperty(ObjectType.MULTI_STATE_VALUE, 39)
+DHW_OPERATION_MODE_COMFORT = 1
+DHW_OPERATION_MODE_ECONOMY = 2
+DHW_OPERATION_MODE_BOOST = 3
+
+# DHW temporary boost (timed)
+DHW_TEMPORARY_BOOST = DeviceProperty(ObjectType.MULTI_STATE_VALUE, 424)
+DHW_TEMPORARY_BOOST_START = 2
+DHW_TEMPORARY_BOOST_STOP = 3
+
+# DHW temperature setpoints
+DHW_TEMPERATURE_SETPOINT_COMFORT = DeviceProperty(ObjectType.ANALOG_VALUE, 253)
+DHW_TEMPERATURE_SETPOINT_ECONOMY = DeviceProperty(ObjectType.ANALOG_VALUE, 2127)
+
+# DHW tank temperatures
+DHW_TANK_TEMPERATURE_BOTTOM = DeviceProperty(ObjectType.ANALOG_INPUT, 58)
+DHW_TANK_TEMPERATURE_MIDDLE = DeviceProperty(ObjectType.ANALOG_INPUT, 69)
+DHW_TANK_TEMPERATURE_TOP = DeviceProperty(ObjectType.ANALOG_INPUT, 70)
+
+# DHW electric heater status (0 - 100%)
+DHW_ELECTRIC_HEATER_STATUS = DeviceProperty(ObjectType.ANALOG_VALUE, 264)
+
+# Room temp.setpoint for heating circuit 1 (e.g. 21.0 degreesCelsius)
+HEATING_CIRCUIT_1_ROOM_TEMPERATURE_SETPOINT = DeviceProperty(ObjectType.ANALOG_VALUE, 1918)
+
+# Heat pump state
+HEAT_PUMP_STATE = DeviceProperty(ObjectType.MULTI_STATE_INPUT, 1)
+HEAT_PUMP_STATE_STANDBY = 1
+HEAT_PUMP_STATE_AIR_PURGE_PROCESS = 2
+HEAT_PUMP_STATE_STARTUP_PROCESS = 3
+HEAT_PUMP_STATE_NORMAL_OPERATION = 4
+HEAT_PUMP_STATE_STOP_PROCESS = 5
+HEAT_PUMP_STATE_DEFROST_OPERATION = 6
+HEAT_PUMP_STATE_STANDBY_WHEN_ERROR = 7
+HEAT_PUMP_STATE_MANUAL_OPERATION = 8
+HEAT_PUMP_STATE_FORCED_FAN_OPERATION = 9
+HEAT_PUMP_STATE_FORCED_PUMP_OPERATION = 10
+
 # List of all DeviceProperties defined in this file
 DEVICE_PROPERTIES = [
     item for _, item in globals().items() if isinstance(item, DeviceProperty)
@@ -175,23 +217,13 @@ DEVICE_PROPERTIES = [
 
 # The first six digits in serial number corresponds to model
 MODELS = {
-    800111: "S2 REL",
-    800121: "S3 REL",
-    800110: "S2 RER",
-    800120: "S3 RER",
-    800221: "CL4 REL",
-    800220: "CL4 RER",
-    800130: "S4 RER",
-    800131: "S4 REL",
-    800210: "CL2 RER",
-    800211: "CL2 REL",
-    800200: "CL3 RER",
-    800201: "CL3 REL",
-    800300: "KS3 RER",
-    800301: "KS3 REL",
+    800481: "W4",
+    800501: "WH4",
+    800502: "W4",
+    800505: "WH4 XL",
 }
 
 # The name of the device
 DEVICE_NAMES = {
-    "HvacFnct21y_A": "Flexit Nordic",
+    "HvacFnct25y_A": "Flexit EcoNordic",
 }


### PR DESCRIPTION
## Overview

This change is based on the previous pull request:  
https://github.com/piotrbulinski/flexit_bacnet/pull/32

This pull request introduces a significant refactoring aimed at supporting multiple Flexit product lines (**Nordic** and **EcoNordic**) by dynamically selecting the appropriate property mapping based on the detected device model. [[1]](https://github.com/piotrbulinski/flexit_bacnet/compare/main...huzvar:econordic?expand=1#diff-b51bd17780929ed41660778089d5b20e7e5d4b0badc3ca12dff2d8aa5c7c60f8R29-R48) It also extends device information fields and improves BACnet object type enumeration.

---

## Support for Multiple Product Lines and Dynamic Property Mapping

`FlexitBACnet` in `device.py` has been refactored to dynamically select the correct property mapping module (`nordic` or `econordic`) at runtime based on the detected device model.

The model must be present in either the **EcoNordic** or **Nordic** model lists. All device property accesses now use the selected mapping, enabling transparent support for both Nordic and EcoNordic product lines. [[1]](https://github.com/piotrbulinski/flexit_bacnet/compare/main...huzvar:econordic?expand=1#diff-b51bd17780929ed41660778089d5b20e7e5d4b0badc3ca12dff2d8aa5c7c60f8R29-R48) [[2]](https://github.com/piotrbulinski/flexit_bacnet/compare/main...huzvar:econordic?expand=1#diff-7f9778b977941bbe65eaa522b844f0bc0b084f332d4346514854e068b381e7afR218-R224) [[3]](https://github.com/piotrbulinski/flexit_bacnet/compare/main...huzvar:econordic?expand=1#diff-9b6ca89978e2b5526bb73c48d1314442c1dac4f28bef376e461b5c698f2d8b75R176-R192)

A new property `product_line` has been added to `FlexitBACnet` to expose the detected product line. [[1]](https://github.com/piotrbulinski/flexit_bacnet/compare/main...huzvar:econordic?expand=1#diff-b51bd17780929ed41660778089d5b20e7e5d4b0badc3ca12dff2d8aa5c7c60f8R82-R85) [[2]](https://github.com/piotrbulinski/flexit_bacnet/compare/main...huzvar:econordic?expand=1#diff-7f9778b977941bbe65eaa522b844f0bc0b084f332d4346514854e068b381e7afR8) [[3]](https://github.com/piotrbulinski/flexit_bacnet/compare/main...huzvar:econordic?expand=1#diff-9b6ca89978e2b5526bb73c48d1314442c1dac4f28bef376e461b5c698f2d8b75R7)

---

## Device and Model Information Improvements

The example script `device_info.py` has been updated to display the detected product line. [[1]](https://github.com/piotrbulinski/flexit_bacnet/compare/main...huzvar:econordic?expand=1#diff-494633491ba190c338cb0cebadc10963a69ac2647d51ff783c86de4c6ea2b7acR24)

For **EcoNordic** devices, it additionally shows fields related to: [[2]](https://github.com/piotrbulinski/flexit_bacnet/compare/main...huzvar:econordic?expand=1#diff-494633491ba190c338cb0cebadc10963a69ac2647d51ff783c86de4c6ea2b7acR77-R86)

- Domestic hot water (DHW)
- Heating

---

## BACnet Object Type Improvements

The `ObjectType` enumeration in `bacnet.py` has been extended with:
MULTI_STATE_INPUT

This improves BACnet protocol coverage. [[1]](https://github.com/piotrbulinski/flexit_bacnet/compare/main...huzvar:econordic?expand=1#diff-1954065683c71f280ee1d8d099a67a238363a1a74c0fa095753d1f4d171b2329R77)

---

## Model Constant Rename

The constant:
NORDIC_MODELS

has been renamed to:
MODELS

This simplifies usage with the new dynamic property mapping approach. [[1]](https://github.com/piotrbulinski/flexit_bacnet/compare/main...huzvar:econordic?expand=1#diff-9b6ca89978e2b5526bb73c48d1314442c1dac4f28bef376e461b5c698f2d8b75L174-R177)

---

## Dynamic Access to Property Constants

With the introduction of dynamic property mapping, direct access to Nordic property constants is no longer reliable because the correct property set must be selected based on the detected device model.

To address this, constants are now exposed dynamically through the `FlexitBACnet` device instance based on the selected property mapping. This ensures that the correct constants are available for both **Nordic** and **EcoNordic** devices. [[1]](https://github.com/piotrbulinski/flexit_bacnet/compare/main...huzvar:econordic?expand=1#diff-b51bd17780929ed41660778089d5b20e7e5d4b0badc3ca12dff2d8aa5c7c60f8R55-R58)

---

## Summary of Changes

- Added support for **EcoNordic** product line
- Implemented **dynamic property mapping** based on detected device model
- Added `product_line` property to expose detected product line
- Introduced **dynamic exposure of property constants** through the device instance
- Removed direct access to Nordic property constants
- Updated `device_info.py` example script
- Extended BACnet `ObjectType` with `MULTI_STATE_INPUT`
- Renamed `NORDIC_MODELS` → `MODELS` to support the new dynamic mapping approach

---

## Backwards Compatibility

This change slightly modifies how property constants are accessed. [[1]](https://github.com/piotrbulinski/flexit_bacnet/pull/33/changes#diff-c77f256438eb9e5330a87f631bfb6fc844b202b38d6c17a30c2c656bba2d8b61L4)

Previously, constants were accessed directly from the Nordic property definitions.  
With the introduction of dynamic property mapping to support multiple product lines (**Nordic** and **EcoNordic**), constants are now exposed dynamically through the `FlexitBACnet` device instance. [[2]](https://github.com/piotrbulinski/flexit_bacnet/pull/33/changes#diff-c53cd125f207a00796aed32fc6b9795727288989d90444b249843c10a63a97fcL5-R5) [[3]](https://github.com/piotrbulinski/flexit_bacnet/pull/33/changes#diff-c53cd125f207a00796aed32fc6b9795727288989d90444b249843c10a63a97fcL29-R28)

In most use cases this change should remain transparent to users, as the constants are still available as attributes of the device object. However, code that relied on directly importing constants from the Nordic property module may need to be updated to access them through the device instance instead. [[4]](https://github.com/piotrbulinski/flexit_bacnet/compare/main...huzvar:econordic?expand=1#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L53-R53) [[5]](https://github.com/piotrbulinski/flexit_bacnet/compare/main...huzvar:econordic?expand=1#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L69-R66)

---

## Testing

Tested with:

- Flexit EcoNordic (Serial Number: 800481-XXXXXX)
- BACnet communication verified
- device_info example updated and validated